### PR TITLE
Add GCC diagnostics to suppress unused-parameter warnings

### DIFF
--- a/source/nordic_sdk/components/softdevice/s130/headers/nrf_svc.h
+++ b/source/nordic_sdk/components/softdevice/s130/headers/nrf_svc.h
@@ -43,6 +43,7 @@
 #elif defined (__GNUC__)
 #define SVCALL(number, return_type, signature) \
   _Pragma("GCC diagnostic ignored \"-Wunused-function\"") \
+  _Pragma("GCC diagnostic ignored \"-Wunused-parameter\"") \
   _Pragma("GCC diagnostic push") \
   _Pragma("GCC diagnostic ignored \"-Wreturn-type\"") \
   __attribute__((naked)) static return_type signature \


### PR DESCRIPTION
@rgrover @LiyouZhou 
