### PR TITLE
Expose function in DM to calculate BLE hash

### DIFF
--- a/source/nordic_sdk/components/ble/peer_manager/id_manager.h
+++ b/source/nordic_sdk/components/ble/peer_manager/id_manager.h
@@ -254,7 +254,7 @@ bool im_address_resolve(ble_gap_addr_t const * p_addr, ble_gap_irk_t const * p_i
  *
  * @note    ====IMPORTANT====
  *          This is a special modification to the original nRF51 SDK required by the mbed BLE API
- *          to being able to generate BLE private resolvable addresses. This function is used by
+ *          to be able to generate BLE private resolvable addresses. This function is used by
  *          the BLE API implementation for nRF5xSecurityManager::getAddressFromBondTable() in the
  *          ble-nrf51822 yotta module.
  *          =================

--- a/source/nordic_sdk/components/ble/peer_manager/id_manager.h
+++ b/source/nordic_sdk/components/ble/peer_manager/id_manager.h
@@ -251,6 +251,13 @@ bool im_address_resolve(ble_gap_addr_t const * p_addr, ble_gap_irk_t const * p_i
  *                          if the irk used in the hash function is the same one used to generate
  *                          the address.
  *                          The array must have a length of 16.
+ *
+ * @note    ====IMPORTANT====
+ *          This is a special modification to the original nRF51 SDK required by the mbed BLE API
+ *          to being able to generate BLE private resolvable addresses. This function is used by
+ *          the BLE API implementation for nRF5xSecurityManager::getAddressFromBondTable() in the
+ *          ble-nrf51822 yotta module.
+ *          =================
  */
 void ah(uint8_t const * p_k, uint8_t const * p_r, uint8_t * p_local_hash);
 

--- a/source/nordic_sdk/components/ble/peer_manager/id_manager.h
+++ b/source/nordic_sdk/components/ble/peer_manager/id_manager.h
@@ -229,6 +229,31 @@ ret_code_t im_wlist_create(pm_peer_id_t        * p_peer_ids,
  */
 bool im_address_resolve(ble_gap_addr_t const * p_addr, ble_gap_irk_t const * p_irk);
 
+/**@brief Function for calculating the ah() hash function described in Bluetooth core specification
+ *        4.2 section 3.H.2.2.2.
+ *
+ * @detail  BLE uses a hash function to calculate the first half of a resolvable address
+ *          from the second half of the address and an irk. This function will use the ECB
+ *          periferal to hash these data acording to the Bluetooth core specification.
+ *
+ * @note The ECB expect little endian input and output.
+ *       This function expect big endian and will reverse the data as necessary.
+ *
+ * @param[in]  p_k          The key used in the hash function.
+ *                          For address resolution this is should be the irk.
+ *                          The array must have a length of 16.
+ * @param[in]  p_r          The rand used in the hash function. For generating a new address
+ *                          this would be a random number. For resolving a resolvable address
+ *                          this would be the last half of the address being resolved.
+ *                          The array must have a length of 3.
+ * @param[out] p_local_hash The result of the hash operation. For address resolution this
+ *                          will match the first half of the address being resolved if and only
+ *                          if the irk used in the hash function is the same one used to generate
+ *                          the address.
+ *                          The array must have a length of 16.
+ */
+void ah(uint8_t const * p_k, uint8_t const * p_r, uint8_t * p_local_hash);
+
 /** @} */
 
 #endif /* PEER_ID_MANAGER_H__ */


### PR DESCRIPTION
The hash function is needed to generate this a new Private Resolvable address.
This functionality is required to generate a table with a list of addresses
from the information in the bond table (See the getAddressesFromBondTable() API
in BLE API SecurityManager). However, this function is not exposed by the
nRF51 SDK to external code. This pull requests simply adds the function
declaration to the relevant .h file to make external use possible.

Refer to https://github.com/ARMmbed/ble-nrf51822/pull/103/files#diff-e2ce540b25070fc6f3c585a68f7d8000R315 for and example usage in the ble-nrf51822 module.
@pan- @LiyouZhou 
