### PR TITLE
Fix build error in fstorage_config.h

### DIFF
--- a/source/nordic_sdk/components/libraries/fstorage/fstorage_config.h
+++ b/source/nordic_sdk/components/libraries/fstorage/fstorage_config.h
@@ -82,7 +82,7 @@
  */
 static __INLINE uint32_t fs_flash_page_end_addr()
 {
-    uint32_t const bootloader_addr = NRF_UICR->NRFFW[0];
+    uint32_t const bootloader_addr = NRF_UICR->BOOTLOADERADDR;
     return  ((bootloader_addr != FS_EMPTY_MASK) ?
              bootloader_addr : NRF_FICR->CODESIZE * FS_PAGE_SIZE);
 }


### PR DESCRIPTION
NRF_UICR->NRFFW[0] is not existing. According to the function documentation I would suggest that the bootloader address is required here
