### PR TITLE
Fix licence issues.

### DIFF
--- a/script/pick_nrf51_files.py
+++ b/script/pick_nrf51_files.py
@@ -1,5 +1,20 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2015-2016 ARM Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os, shutil, json, pprint, sys
 from collections import OrderedDict
 

--- a/script/replace_headers.py
+++ b/script/replace_headers.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2015-2016 ARM Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 
 with open("copyright_header.txt", "r") as fd:


### PR DESCRIPTION
- provide the file `apache-2.0.txt` as mentionned in `LICENCE`.
- add a apache 2 licence header to script/pick_nrf51_files.py.
- add a apache 2 licence header to script/replace_headers.py.
